### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,15 +19,15 @@ Imports:
     Formula,
     Rcpp (>= 0.12.0),
     Rdpack,
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.0.0)
 RdMacros: Rdpack
 LinkingTo: 
     BH (>= 1.66.0),
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 RoxygenNote: 7.2.3
 Suggests: 

--- a/inst/stan/yppe.stan
+++ b/inst/stan/yppe.stan
@@ -9,7 +9,7 @@ data{
   int<lower=0> p;
   int survreg;
   vector[n] status;
-  int idt[n];
+  array[n] int idt;
   matrix[q == 0 ? 0 : n, q] Z;
   matrix[p == 0 ? 0 : n, p] X;
   real<lower=0> tau;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
